### PR TITLE
Handling Empty Attribute Manifest Check

### DIFF
--- a/manifest-scanner/src/plugins/manifest/AllowBackupRule.ts
+++ b/manifest-scanner/src/plugins/manifest/AllowBackupRule.ts
@@ -15,7 +15,7 @@ export default class AllowBackupRule extends ManifestPlugin {
   run(): void {
     console.log('✅ Running AllowBackupRule')
     const applicationTag = ManifestPlugin.manifestXMLObject.manifest.application
-    if (applicationTag) {
+    if (applicationTag && applicationTag.length > 0 && applicationTag[0].$) {
       const allowBackupAttribute = applicationTag[0].$['android:allowBackup']
 
       if (allowBackupAttribute && allowBackupAttribute === 'true') {

--- a/manifest-scanner/src/plugins/manifest/AndroidDebuggableRule.ts
+++ b/manifest-scanner/src/plugins/manifest/AndroidDebuggableRule.ts
@@ -19,7 +19,7 @@ automatically by the tools',
   run(): void {
     console.log('✅ Running AndroidDebuggableRule')
     const applicationTag = ManifestPlugin.manifestXMLObject.manifest.application
-    if (applicationTag) {
+    if (applicationTag && applicationTag.length > 0 && applicationTag[0].$) {
       const allowBackupAttribute = applicationTag[0].$['android:debuggable']
 
       if (allowBackupAttribute && allowBackupAttribute === 'true') {


### PR DESCRIPTION
Addressed #5 by adding empty attribute check for manifest application tag.

- tested empty and non-empty manifest tags
- fixed allow backup rule and debuggable rule